### PR TITLE
fix : embedded word typo

### DIFF
--- a/modules/launch_util.py
+++ b/modules/launch_util.py
@@ -10,7 +10,7 @@ import importlib.metadata
 import packaging.version
 import pygit2
 from pathlib import Path
-from build_launcher import python_embeded_path
+from build_launcher import python_embedded_path
 
 pygit2.option(pygit2.GIT_OPT_SET_OWNER_VALIDATION, 0)
 
@@ -25,7 +25,7 @@ python = sys.executable
 default_command_live = (os.environ.get('LAUNCH_LIVE_OUTPUT') == "1")
 index_url = os.environ.get('INDEX_URL', "https://pypi.tuna.tsinghua.edu.cn/simple")
 
-target_path_install = f' -t {os.path.join(python_embeded_path, "Lib/site-packages")}' if sys.platform.startswith("win") else ''
+target_path_install = f' -t {os.path.join(python_embedded_path, "Lib/site-packages")}' if sys.platform.startswith("win") else ''
 
 modules_path = os.path.dirname(os.path.realpath(__file__))
 script_path = os.path.dirname(modules_path)


### PR DESCRIPTION
This fixes a typo which caused the following error when starting the `run_FooocusPlus.bat` : 

```
Traceback (most recent call last):
  File "C:\palette\apl\FooocusPlus\FooocusPlusAI\entry_with_update.py", line 75, in <module>
    from launch import *
  File "C:\palette\apl\FooocusPlus\FooocusPlusAI\launch.py", line 26, in <module>
    from modules.launch_util import is_installed, run, python, run_pip, requirements_met, delete_folder_content
  File "C:\palette\apl\FooocusPlus\FooocusPlusAI\modules\launch_util.py", line 13, in <module>
    from build_launcher import python_embeded_path
ImportError: cannot import name 'python_embeded_path' from 'build_launcher' (C:\palette\apl\FooocusPlus\FooocusPlusAI\build_launcher.py)
```